### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-TFA433          KEYWORD1
-tfaResult       KEYWORD1
-start           KEYWORD2
-stop            KEYWORD2
-isDataAvailable KEYWORD2
-getData         KEYWORD2
+TFA433	KEYWORD1
+tfaResult	KEYWORD1
+start	KEYWORD2
+stop	KEYWORD2
+isDataAvailable	KEYWORD2
+getData	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords